### PR TITLE
Use raw string literals when specifying regexp.

### DIFF
--- a/environments.py
+++ b/environments.py
@@ -34,8 +34,8 @@ def find_max_env(dir):
     print("dir", dir)
     try:
         for f in os.listdir(dir + 'pkl/'):
-            if re.match('env_(\d+)\.pkl', f):
-                env_num = int(re.match('env_(\d+)\.pkl', f)[1])
+            if re.match(r'env_(\d+)\.pkl', f):
+                env_num = int(re.match(r'env_(\d+)\.pkl', f)[1])
                 if env_num > max_env:
                     max_env = env_num
         return(max_env)


### PR DESCRIPTION
This fixes the syntax error on current python 3 version. The error is due to that fact that string literals contain unicode characters. In unicode, there is a fixed set of valid escape sequences - and \d is not one of them, so \d is interpreted as in invalid unicode escape seqence.

The best solution is to use a raw string literal r"\d" - here backslashes are interpreted as just that, instead of as the beginning of a unicode escape sequence - and thus we can safely use raw string literals to write regular expressions.